### PR TITLE
Get away from master/slave phrasing

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -191,11 +191,11 @@ def connect(site=None, db_name=None):
 def connect_read_only():
 	from frappe.database import Database
 
-	local.read_only_db = Database(local.conf.slave_host, local.conf.slave_db_name,
-		local.conf.slave_db_password)
+	local.read_only_db = Database(local.conf.subordinate_host, local.conf.subordinate_db_name,
+		local.conf.subordinate_db_password)
 
 	# swap db connections
-	local.master_db = local.db
+	local.main_db = local.db
 	local.db = local.read_only_db
 
 def get_site_config(sites_path=None, site_path=None):
@@ -496,16 +496,16 @@ def whitelist(allow_guest=False, xss_safe=False):
 def read_only():
 	def innfn(fn):
 		def wrapper_fn(*args, **kwargs):
-			if conf.use_slave_for_read_only:
+			if conf.use_subordinate_for_read_only:
 				connect_read_only()
 			try:
 				retval = fn(*args, **get_newargs(fn, kwargs))
 			except:
 				raise
 			finally:
-				if local and hasattr(local, 'master_db'):
+				if local and hasattr(local, 'main_db'):
 					local.db.close()
-					local.db = local.master_db
+					local.db = local.main_db
 
 			return retval
 		return wrapper_fn

--- a/frappe/desk/tags.py
+++ b/frappe/desk/tags.py
@@ -38,7 +38,7 @@ def check_user_tags(dt):
 
 @frappe.whitelist()
 def add_tag(tag, dt, dn, color=None):
-	"adds a new tag to a record, and creates the Tag master"
+	"adds a new tag to a record, and creates the Tag main"
 	DocTags(dt).add(dn, tag)
 
 	return tag

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -439,8 +439,8 @@ def bulk_rename(doctype, rows=None, via_console = False):
 def update_linked_doctypes(doctype, docname, linked_to, value, ignore_doctypes=None):
 	"""
 		linked_doctype_info_list = list formed by get_fetch_fields() function
-		docname = Master DocType's name in which modification are made
-		value = Value for the field thats set in other DocType's by fetching from Master DocType
+		docname = Main DocType's name in which modification are made
+		value = Value for the field thats set in other DocType's by fetching from Main DocType
 	"""
 	linked_doctype_info_list = get_fetch_fields(doctype, linked_to, ignore_doctypes)
 
@@ -451,37 +451,37 @@ def update_linked_doctypes(doctype, docname, linked_to, value, ignore_doctypes=N
 			set
 				{linked_to_fieldname} = "{value}"
 			where
-				{master_fieldname} = "{docname}"
+				{main_fieldname} = "{docname}"
 				and {linked_to_fieldname} != "{value}"
 		""".format(
 			doctype = d['doctype'],
 			linked_to_fieldname = d['linked_to_fieldname'],
 			value = value,
-			master_fieldname = d['master_fieldname'],
+			main_fieldname = d['main_fieldname'],
 			docname = docname
 		))
 
 def get_fetch_fields(doctype, linked_to, ignore_doctypes=None):
 	"""
-		doctype = Master DocType in which the changes are being made
-		linked_to = DocType name of the field thats being updated in Master
+		doctype = Main DocType in which the changes are being made
+		linked_to = DocType name of the field thats being updated in Main
 
 		This function fetches list of all DocType where both doctype and linked_to is found
 		as link fields.
 		Forms a list of dict in the form -
-			[{doctype: , master_fieldname: , linked_to_fieldname: ]
+			[{doctype: , main_fieldname: , linked_to_fieldname: ]
 		where
 			doctype = DocType where changes need to be made
-			master_fieldname = Fieldname where options = doctype
+			main_fieldname = Fieldname where options = doctype
 			linked_to_fieldname = Fieldname where options = linked_to
 	"""
 
-	master_list = get_link_fields(doctype)
+	main_list = get_link_fields(doctype)
 	linked_to_list = get_link_fields(linked_to)
 	out = []
 
 	from itertools import product
-	product_list = product(master_list, linked_to_list)
+	product_list = product(main_list, linked_to_list)
 
 	for d in product_list:
 		linked_doctype_info = frappe._dict()
@@ -489,7 +489,7 @@ def get_fetch_fields(doctype, linked_to, ignore_doctypes=None):
 				and (not ignore_doctypes or d[0]['parent'] not in ignore_doctypes) \
 				and not d[1]['issingle']:
 			linked_doctype_info['doctype'] = d[0]['parent']
-			linked_doctype_info['master_fieldname'] = d[0]['fieldname']
+			linked_doctype_info['main_fieldname'] = d[0]['fieldname']
 			linked_doctype_info['linked_to_fieldname'] = d[1]['fieldname']
 			out.append(linked_doctype_info)
 

--- a/frappe/patches/v11_0/rename_workflow_action_to_workflow_action_master.py
+++ b/frappe/patches/v11_0/rename_workflow_action_to_workflow_action_master.py
@@ -4,6 +4,6 @@ from frappe.model.rename_doc import rename_doc
 
 
 def execute():
-	if frappe.db.table_exists("Workflow Action") and not frappe.db.table_exists("Workflow Action Master"):
-		rename_doc('DocType', 'Workflow Action', 'Workflow Action Master')
-		frappe.reload_doc('workflow', 'doctype', 'workflow_action_master')
+	if frappe.db.table_exists("Workflow Action") and not frappe.db.table_exists("Workflow Action Main"):
+		rename_doc('DocType', 'Workflow Action', 'Workflow Action Main')
+		frappe.reload_doc('workflow', 'doctype', 'workflow_action_main')

--- a/frappe/patches/v8_0/deprecate_integration_broker.py
+++ b/frappe/patches/v8_0/deprecate_integration_broker.py
@@ -10,7 +10,7 @@ def execute():
 	
 	frappe.reload_doc("core", "doctype", "payment_gateway")
 	update_doctype_module()
-	create_payment_gateway_master_records()
+	create_payment_gateway_main_records()
 
 	for doctype in ["Integration Service", "Integration Service Parameter"]:
 		frappe.delete_doc("DocType", doctype)
@@ -35,7 +35,7 @@ def update_doctype_module():
 
 	frappe.db.sql(""" update tabDocType set module='Core' where name = 'Payment Gateway'""")
 
-def create_payment_gateway_master_records():
+def create_payment_gateway_main_records():
 	for payment_gateway in ["Razorpay", "PayPal"]:
 		doctype = "{0} Settings".format(payment_gateway)
 		doc = frappe.get_doc(doctype)

--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -103,7 +103,7 @@ def get_versions():
 			"branch": get_app_branch(app)
 		}
 
-		if versions[app]['branch'] != 'master':
+		if versions[app]['branch'] != 'main':
 			branch_version = app_hooks.get('{0}_version'.format(versions[app]['branch']))
 			if branch_version:
 				versions[app]['branch_version'] = branch_version[0] + ' ({0})'.format(get_app_last_commit_ref(app))


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.